### PR TITLE
Separate energy counters for IN/OUT

### DIFF
--- a/emonLibCM.h
+++ b/emonLibCM.h
@@ -102,6 +102,8 @@ double EmonLibCM_getVrms(void);
 double EmonLibCM_getDatalog_period(void);
 double EmonLibCM_getLineFrequency(void);
 long EmonLibCM_getWattHour(int channel);
+long EmonLibCM_getWattHourIn(int channel);
+long EmonLibCM_getWattHourOut(int channel);
 unsigned long EmonLibCM_getPulseCount(void);
 
 


### PR DESCRIPTION
There may be another way to do this..

In my emonTX setup, I have solar PV, but I don't have access to clamp the solar production, only at the grid.

Since there are times of day where the energy is flowing out - negative - this is currently reducing the energy count for
that channel. Unfortunately it doesn't mean my meter also flows backwards, so it's thus very hard to compare the values. I don't have an export meter, so one of the uses of having the emonTx there is to be able to work out what proportion is being used on-site and what is being exported.

I've modified it to split the wh out and in. It might be better to wrap the wh_ and residual_energy, and even the channel_in_use in a struct. I retained the old EmonLibCM_getWattHour API for compatibility.

