### PR TITLE
examples: The 'max' example has a typo in 'include' statement

### DIFF
--- a/Examples/EmonTxV34CM_max/EmonTxV34CM_max.ino
+++ b/Examples/EmonTxV34CM_max/EmonTxV34CM_max.ino
@@ -11,7 +11,7 @@ Application Interface section of the User Documentation gives full details.
 */
 
 #include <Arduino.h>
-#include "emonLibCMx.h"
+#include "emonLibCM.h"
 
 #define RF69_COMPAT 0                                      //  Set to 1 if using RFM69CW, or 0 if using RFM12B
 #include <JeeLib.h>                                        //  https://github.com/jcw/jeelib - Tested with JeeLib 10 April 2017


### PR DESCRIPTION
There appears to be a typo in the #include directive in the 'max' example. Removing the trailing 'x' allows the Sketch to compile (via the Arduino IDE 2.0).